### PR TITLE
[SSDP-174] Refactoring of kafka source and adding state support

### DIFF
--- a/airbyte-integrations/connectors/source-kafka/Dockerfile
+++ b/airbyte-integrations/connectors/source-kafka/Dockerfile
@@ -24,5 +24,5 @@ ENV APPLICATION source-kafka
 
 COPY --from=build /airbyte /airbyte
 
-LABEL io.airbyte.version=0.2.3
+LABEL io.airbyte.version=0.3.0
 LABEL io.airbyte.name=airbyte/source-kafka

--- a/airbyte-integrations/connectors/source-kafka/metadata.yaml
+++ b/airbyte-integrations/connectors/source-kafka/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: d917a47b-8537-4d0d-8c10-36a9928d4265
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.3.0
   dockerRepository: airbyte/source-kafka
   githubIssueLabel: source-kafka
   icon: kafka.svg

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/KafkaConsumerRebalanceListener.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/KafkaConsumerRebalanceListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.kafka;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+
+public class KafkaConsumerRebalanceListener implements ConsumerRebalanceListener {
+
+  public KafkaConsumerRebalanceListener(final KafkaConsumer<?, ?> consumer, final Map<TopicPartition, Long> positions) {
+    this.consumer = consumer;
+    this.positions = positions;
+  }
+
+  @Override
+  public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {
+
+  }
+
+  @Override
+  public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {
+    partitions.forEach(partition -> Optional.ofNullable(positions.get(partition)).ifPresent(position -> consumer.seek(partition, position)));
+  }
+
+  private final KafkaConsumer<?, ?> consumer;
+  private final Map<TopicPartition, Long> positions;
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/KafkaMessage.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/KafkaMessage.java
@@ -1,0 +1,7 @@
+package io.airbyte.integrations.source.kafka;
+
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+
+public record KafkaMessage(String topic, int partition, long offset, AirbyteRecordMessage message) {
+
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/KafkaSource.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/KafkaSource.java
@@ -9,7 +9,10 @@ import io.airbyte.commons.util.AutoCloseableIterator;
 import io.airbyte.integrations.BaseConnector;
 import io.airbyte.integrations.base.IntegrationRunner;
 import io.airbyte.integrations.base.Source;
+import io.airbyte.integrations.source.kafka.config.ConfigHelper;
 import io.airbyte.integrations.source.kafka.format.KafkaFormat;
+import io.airbyte.integrations.source.kafka.generator.GeneratorHelper;
+import io.airbyte.integrations.source.kafka.state.StateHelper;
 import io.airbyte.protocol.models.v0.AirbyteCatalog;
 import io.airbyte.protocol.models.v0.AirbyteConnectionStatus;
 import io.airbyte.protocol.models.v0.AirbyteConnectionStatus.Status;
@@ -24,7 +27,8 @@ public class KafkaSource extends BaseConnector implements Source {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(KafkaSource.class);
 
-  public KafkaSource() {}
+  public KafkaSource() {
+  }
 
   @Override
   public AirbyteConnectionStatus check(final JsonNode config) {
@@ -51,8 +55,11 @@ public class KafkaSource extends BaseConnector implements Source {
     if (check.getStatus().equals(AirbyteConnectionStatus.Status.FAILED)) {
       throw new RuntimeException("Unable establish a connection: " + check.getMessage());
     }
-    KafkaFormat kafkaFormat = KafkaFormatFactory.getFormat(config);
-    return kafkaFormat.read();
+    final var parsedConfig = ConfigHelper.fromJson(config);
+    final var offsets = StateHelper.stateFromJson(state);
+    final var generator = GeneratorHelper.buildFrom(parsedConfig, offsets);
+
+    return generator.read();
   }
 
   public static void main(final String[] args) throws Exception {

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/config/ConfigHelper.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/config/ConfigHelper.java
@@ -1,0 +1,124 @@
+package io.airbyte.integrations.source.kafka.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.source.kafka.KafkaProtocol;
+import io.airbyte.integrations.source.kafka.KafkaStrategy;
+import io.airbyte.integrations.source.kafka.MessageFormat;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.connect.json.JsonDeserializer;
+
+public class ConfigHelper {
+
+  public static SourceConfig fromJson(JsonNode config) {
+    final var messageFormat = MessageFormat.valueOf(
+        Optional.ofNullable(config.get("MessageFormat")).map(it -> it.get("deserialization_type").asText().toUpperCase()).orElse("JSON")
+    );
+    final var maxRecords = config.has("max_records_process") ? config.get("max_records_process").intValue() : 100000;
+    final var maxRetries = config.has("repeated_calls") ? config.get("repeated_calls").intValue() : 0;
+    final var pollingTimeInMs = config.has("polling_time") ? config.get("polling_time").intValue() : 100;
+    final var kafkaConfig = new KafkaConfig(getKafkaConfigByFormat(config, messageFormat), getKafkaSubscriptionConfig(config));
+    return new SourceConfig(messageFormat, kafkaConfig, maxRecords, maxRetries, pollingTimeInMs);
+  }
+
+  private static Map<String, Object> getKafkaConfigByFormat(JsonNode config, MessageFormat format) {
+    Map<String, Object> props = getKafkaProperties(config);
+
+    switch (format) {
+      case AVRO -> {
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
+        props.put(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
+        final JsonNode avroConfig = config.get("MessageFormat");
+        props.put(SchemaRegistryClientConfig.USER_INFO_CONFIG,
+            String.format("%s:%s", avroConfig.get("schema_registry_username").asText(), avroConfig.get("schema_registry_password").asText()));
+        props.put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, avroConfig.get("schema_registry_url").asText());
+        props.put(KafkaAvroSerializerConfig.VALUE_SUBJECT_NAME_STRATEGY,
+            KafkaStrategy.getStrategyName(avroConfig.get("deserialization_strategy").asText()));
+      }
+      case JSON -> {
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class.getName());
+      }
+    }
+
+    return props;
+  }
+
+  private static Map<String, Object> getKafkaProperties(JsonNode config) {
+    final Map<String, Object> props = new HashMap<>();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, config.get("bootstrap_servers").asText());
+    props.put(ConsumerConfig.GROUP_ID_CONFIG,
+        config.has("group_id") ? config.get("group_id").asText() : null);
+    props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG,
+        config.has("max_poll_records") ? config.get("max_poll_records").intValue() : null);
+    props.putAll(getSecurityProtocolConfig(config));
+    props.put(ConsumerConfig.CLIENT_ID_CONFIG,
+        config.has("client_id") ? config.get("client_id").asText() : null);
+    props.put(ConsumerConfig.CLIENT_DNS_LOOKUP_CONFIG, config.get("client_dns_lookup").asText());
+    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, config.get("enable_auto_commit").booleanValue());
+    props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG,
+        config.has("auto_commit_interval_ms") ? config.get("auto_commit_interval_ms").intValue() : null);
+    props.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG,
+        config.has("retry_backoff_ms") ? config.get("retry_backoff_ms").intValue() : null);
+    props.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG,
+        config.has("request_timeout_ms") ? config.get("request_timeout_ms").intValue() : null);
+    props.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG,
+        config.has("receive_buffer_bytes") ? config.get("receive_buffer_bytes").intValue() : null);
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+        config.has("auto_offset_reset") ? config.get("auto_offset_reset").asText() : null);
+
+    return props.entrySet().stream()
+        .filter(entry -> entry.getValue() != null && !entry.getValue().toString().isBlank())
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  private static Map<String, String> getKafkaSubscriptionConfig(JsonNode config) {
+    final Map<String, String> props = new HashMap<>();
+    final var subscription = config.get("subscription");
+
+    props.put("subscription_type", subscription.get("subscription_type").asText());
+
+    if (subscription.get("topic_pattern") != null) {
+      props.put("topic_pattern", subscription.get("topic_pattern").asText());
+    }
+
+    if (subscription.get("topic_partitions") != null) {
+      props.put("topic_partitions", subscription.get("topic_partitions").asText());
+    }
+
+    return props;
+  }
+
+  private static Map<String, Object> getSecurityProtocolConfig(final JsonNode config) {
+    final JsonNode protocolConfig = config.get("protocol");
+    final KafkaProtocol protocol = KafkaProtocol.valueOf(protocolConfig.get("security_protocol").asText().toUpperCase());
+    final Map<String, Object> props = new HashMap<>();
+
+    props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, protocol.toString());
+
+    switch (protocol) {
+      case PLAINTEXT -> {
+      }
+      case SASL_SSL, SASL_PLAINTEXT -> {
+        props.put(SaslConfigs.SASL_JAAS_CONFIG, protocolConfig.get("sasl_jaas_config").asText());
+        props.put(SaslConfigs.SASL_MECHANISM, protocolConfig.get("sasl_mechanism").asText());
+      }
+      default -> throw new RuntimeException("Unexpected Kafka protocol: " + Jsons.serialize(protocol));
+    }
+
+    return props;
+  }
+
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/config/KafkaConfig.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/config/KafkaConfig.java
@@ -1,0 +1,7 @@
+package io.airbyte.integrations.source.kafka.config;
+
+import java.util.Map;
+
+public record KafkaConfig(Map<String, Object> properties, Map<String, String> subscription) {
+
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/config/SourceConfig.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/config/SourceConfig.java
@@ -1,0 +1,7 @@
+package io.airbyte.integrations.source.kafka.config;
+
+import io.airbyte.integrations.source.kafka.MessageFormat;
+
+public record SourceConfig(MessageFormat format, KafkaConfig kafkaConfig, int maxRecords, int maxRetries, int pollingTimeInMs) {
+
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/converter/AvroConverter.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/converter/AvroConverter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.kafka.converter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+import java.time.Instant;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.lang3.StringUtils;
+
+public class AvroConverter implements Converter<GenericRecord> {
+
+  @Override
+  public AirbyteRecordMessage convertToAirbyteRecord(String topic, GenericRecord value) {
+    String namespace = value.getSchema().getNamespace();
+    String name = value.getSchema().getName();
+    JsonNode output = Jsons.deserialize(value.toString());
+
+    // Todo dynamic namespace is not supported now hence, adding avro schema name in the message
+    // NB this is adding a new column to the data, I don't know whether we really want it
+    if (StringUtils.isNoneEmpty(namespace) && StringUtils.isNoneEmpty(name)) {
+      String newString = String.format("{ \"avro_schema\": \"%s\",\"name\": \"%s\" }", namespace, name);
+      ((ObjectNode) output).set("_namespace_", Jsons.deserialize(newString));
+    }
+
+    return new AirbyteRecordMessage()
+        .withStream(topic)
+        .withEmittedAt(Instant.now().toEpochMilli())
+        .withData(output);
+  }
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/converter/Converter.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/converter/Converter.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.kafka.converter;
+
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+
+public interface Converter<V> {
+
+  AirbyteRecordMessage convertToAirbyteRecord(String topic, V value);
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/converter/JsonConverter.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/converter/JsonConverter.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.kafka.converter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+import java.time.Instant;
+
+public class JsonConverter implements Converter<JsonNode> {
+
+  @Override
+  public AirbyteRecordMessage convertToAirbyteRecord(String topic, JsonNode value) {
+    return new AirbyteRecordMessage()
+        .withStream(topic)
+        .withEmittedAt(Instant.now().toEpochMilli())
+        .withData(value);
+  }
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/generator/Generator.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/generator/Generator.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.kafka.generator;
+
+import com.google.common.collect.AbstractIterator;
+import io.airbyte.commons.util.AutoCloseableIterator;
+import io.airbyte.commons.util.AutoCloseableIterators;
+import io.airbyte.integrations.source.kafka.KafkaMessage;
+import io.airbyte.integrations.source.kafka.mediator.KafkaMediator;
+import io.airbyte.integrations.source.kafka.state.StateHelper;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.AirbyteStateMessage;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import org.apache.kafka.common.TopicPartition;
+
+final public class Generator {
+
+  private final KafkaMediator mediator;
+  private final int maxRecords;
+  private final int maxRetries;
+
+  public Generator(Builder builder) {
+    this.maxRecords = builder.maxRecords;
+    this.maxRetries = builder.maxRetries;
+    this.mediator = builder.mediator;
+  }
+
+  public static class Builder {
+
+    private KafkaMediator mediator;
+    private int maxRecords = 100000;
+    private int maxRetries = 10;
+
+    public static Builder newInstance() {
+      return new Builder();
+    }
+
+    private Builder() {
+    }
+
+    public Builder withMaxRecords(int maxRecords) {
+      this.maxRecords = maxRecords;
+      return this;
+    }
+
+    public Builder withMaxRetries(int maxRetries) {
+      this.maxRetries = maxRetries;
+      return this;
+    }
+
+    public Builder withMediator(KafkaMediator mediator) {
+      this.mediator = mediator;
+      return this;
+    }
+
+    public Generator build() {
+      return new Generator(this);
+    }
+
+  }
+
+  public AutoCloseableIterator<AirbyteMessage> read() {
+
+    return AutoCloseableIterators.fromIterator(new AbstractIterator<>() {
+
+      private int totalRead = 0;
+      private final Queue<AirbyteMessage> pendingMessages = new LinkedList<>();
+
+      @Override
+      protected AirbyteMessage computeNext() {
+        if (this.pendingMessages.isEmpty()) {
+          if (this.totalRead < Generator.this.maxRecords) {
+            List<KafkaMessage> batch = pullBatchFromKafka();
+            if (!batch.isEmpty()) {
+              this.totalRead += batch.size();
+              this.pendingMessages.addAll(convertToAirbyteMessagesWithState(batch));
+            }
+          } else {
+            return endOfData();
+          }
+        }
+
+        // If no more pending kafka records, close iterator
+        if (this.pendingMessages.isEmpty()) {
+          return endOfData();
+        } else {
+          return pendingMessages.poll();
+        }
+      }
+
+      private List<AirbyteMessage> convertToAirbyteMessagesWithState(List<KafkaMessage> batch) {
+        final Set<TopicPartition> partitions = new HashSet<>();
+        final List<AirbyteMessage> messages = new ArrayList<>();
+
+        for (KafkaMessage entry : batch) {
+          final var topic = entry.topic();
+          final var partition = entry.partition();
+          final var message = entry.message();
+          partitions.add(new TopicPartition(topic, partition));
+          messages.add(new AirbyteMessage().withType(AirbyteMessage.Type.RECORD).withRecord(message));
+        }
+
+        final var offsets = Generator.this.mediator.position(partitions);
+
+        for (AirbyteStateMessage entry : StateHelper.toAirbyteState(offsets)) {
+          messages.add(new AirbyteMessage().withType(AirbyteMessage.Type.STATE).withState(entry));
+        }
+
+        return messages;
+      }
+
+      private List<KafkaMessage> pullBatchFromKafka() {
+        List<KafkaMessage> batch;
+        var nrOfRetries = 0;
+        do {
+          batch = Generator.this.mediator.poll();
+        } while (batch.isEmpty() && ++nrOfRetries < Generator.this.maxRetries);
+        return batch;
+      }
+    });
+  }
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/generator/GeneratorHelper.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/generator/GeneratorHelper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.kafka.generator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.source.kafka.config.SourceConfig;
+import io.airbyte.integrations.source.kafka.converter.AvroConverter;
+import io.airbyte.integrations.source.kafka.converter.Converter;
+import io.airbyte.integrations.source.kafka.converter.JsonConverter;
+import io.airbyte.integrations.source.kafka.mediator.DefaultKafkaMediator;
+import io.airbyte.integrations.source.kafka.mediator.KafkaMediator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+
+public class GeneratorHelper {
+
+  public static Generator buildFrom(SourceConfig config, Map<TopicPartition, Long> initialOffsets) {
+    return switch (config.format()) {
+      case AVRO -> {
+        final KafkaConsumer<String, GenericRecord> consumer = new KafkaConsumer<>(config.kafkaConfig().properties());
+        final Converter<GenericRecord> converter = new AvroConverter();
+        final KafkaMediator mediator = new DefaultKafkaMediator<>(consumer, converter, config.pollingTimeInMs(),
+            config.kafkaConfig().subscription(),
+            initialOffsets);
+
+        yield Generator.Builder.newInstance()
+            .withMaxRecords(config.maxRecords())
+            .withMaxRetries(config.maxRetries())
+            .withMediator(mediator).build();
+      }
+      case JSON -> {
+        final KafkaConsumer<String, JsonNode> consumer = new KafkaConsumer<>(config.kafkaConfig().properties());
+        final Converter<JsonNode> converter = new JsonConverter();
+        final KafkaMediator mediator = new DefaultKafkaMediator<>(consumer, converter, config.pollingTimeInMs(),
+            config.kafkaConfig().subscription(),
+            initialOffsets);
+
+        yield Generator.Builder.newInstance()
+            .withMaxRecords(config.maxRecords())
+            .withMaxRetries(config.maxRetries())
+            .withMediator(mediator)
+            .build();
+      }
+    };
+  }
+
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/mediator/DefaultKafkaMediator.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/mediator/DefaultKafkaMediator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.kafka.mediator;
+
+import io.airbyte.integrations.source.kafka.KafkaConsumerRebalanceListener;
+import io.airbyte.integrations.source.kafka.KafkaMessage;
+import io.airbyte.integrations.source.kafka.converter.Converter;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultKafkaMediator<V> implements KafkaMediator {
+
+  private final KafkaConsumer<String, V> consumer;
+  private final Converter<V> converter;
+  private final int pollingTimeInMs;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultKafkaMediator.class);
+
+  public DefaultKafkaMediator(KafkaConsumer<String, V> consumer, Converter<V> converter, int pollingTimeInMs,
+      Map<String, String> subscription, Map<TopicPartition, Long> initialOffsets) {
+    final KafkaConsumerRebalanceListener listener = new KafkaConsumerRebalanceListener(consumer, initialOffsets);
+    LOGGER.info("Kafka subscribe method: {}", subscription.toString());
+    switch (subscription.get("subscription_type")) {
+      case "subscribe" -> {
+        final String topicPattern = subscription.get("topic_pattern");
+        consumer.subscribe(Pattern.compile(topicPattern), listener);
+      }
+      case "assign" -> {
+        final String topicPartitions = subscription.get("topic_partitions");
+        final String[] topicPartitionsStr = topicPartitions.replaceAll("\\s+", "").split(",");
+        final List<TopicPartition> topicPartitionList = Arrays.stream(topicPartitionsStr).map(topicPartition -> {
+          final String[] pair = topicPartition.split(":");
+          return new TopicPartition(pair[0], Integer.parseInt(pair[1]));
+        }).collect(Collectors.toList());
+        LOGGER.info("Topic-partition list: {}", topicPartitionList);
+        consumer.assign(topicPartitionList);
+        topicPartitionList.forEach(partition -> Optional.ofNullable(initialOffsets.get(partition))
+            .ifPresent(offset -> consumer.seek(partition, offset)));
+      }
+    }
+
+    this.consumer = consumer;
+    this.converter = converter;
+    this.pollingTimeInMs = pollingTimeInMs;
+  }
+
+  @Override
+  public List<KafkaMessage> poll() {
+    List<KafkaMessage> output = new ArrayList<>();
+    consumer.poll(Duration.of(this.pollingTimeInMs, ChronoUnit.MILLIS)).forEach(it -> {
+      final var message = new KafkaMessage(it.topic(), it.partition(), it.offset(), this.converter.convertToAirbyteRecord(it.topic(), it.value()));
+      output.add(message);
+    });
+    return output;
+  }
+
+  @Override
+  public Map<TopicPartition, Long> position(Set<TopicPartition> partitions) {
+    return partitions.stream()
+        .map(it -> Map.entry(it, consumer.position(it)))
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+  }
+
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/mediator/KafkaMediator.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/mediator/KafkaMediator.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.kafka.mediator;
+
+import io.airbyte.integrations.source.kafka.KafkaMessage;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.common.TopicPartition;
+
+public interface KafkaMediator {
+
+  List<KafkaMessage> poll();
+
+  Map<TopicPartition, Long> position(Set<TopicPartition> partitions);
+
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/state/State.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/state/State.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.kafka.state;
+
+import java.util.Map;
+
+public record State(Map<Integer, Long> partitions) {
+
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/state/StateHelper.java
+++ b/airbyte-integrations/connectors/source-kafka/src/main/java/io/airbyte/integrations/source/kafka/state/StateHelper.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.kafka.state;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.configoss.StateWrapper;
+import io.airbyte.configoss.helpers.StateMessageHelper;
+import io.airbyte.protocol.models.v0.AirbyteStateMessage;
+import io.airbyte.protocol.models.v0.AirbyteStreamState;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import org.apache.kafka.common.TopicPartition;
+
+public class StateHelper {
+
+  public static Map<TopicPartition, Long> stateFromJson(JsonNode state) {
+    final boolean USE_STREAM_CAPABLE_STATE = true;
+    final Optional<StateWrapper> wrapper = StateMessageHelper.getTypedState(state, USE_STREAM_CAPABLE_STATE);
+    final var serialisedState = wrapper.map(value ->
+        switch (value.getStateType()) {
+          case GLOBAL -> fromAirbyteStreamState(value.getGlobal().getGlobal().getStreamStates());
+          case STREAM -> fromAirbyteStreamState(value.getStateMessages().stream().map(it -> it.getStream()).toList());
+          case LEGACY -> new HashMap<TopicPartition, Long>();
+        }
+    );
+
+    return serialisedState.orElse(new HashMap<>());
+  }
+
+  public static List<AirbyteStateMessage> toAirbyteState(Map<TopicPartition, Long> state) {
+    final Map<String, Map<Integer, Long>> intermediate = new HashMap<>();
+
+    for (final Entry<TopicPartition, Long> entry : state.entrySet()) {
+      final var topic = entry.getKey().topic();
+      final var partition = entry.getKey().partition();
+      final var offset = entry.getValue();
+      if (!intermediate.containsKey(topic)) {
+        intermediate.put(topic, new HashMap<>());
+      }
+      intermediate.get(topic).put(partition, offset);
+    }
+
+    return intermediate
+        .entrySet()
+        .stream()
+        .map(it ->
+            new AirbyteStateMessage()
+                .withType(AirbyteStateMessage.AirbyteStateType.STREAM)
+                .withStream(new AirbyteStreamState()
+                    .withStreamDescriptor(new StreamDescriptor().withName(it.getKey()))
+                    .withStreamState(Jsons.jsonNode(new State(it.getValue()))))
+        )
+        .toList();
+  }
+
+  private static HashMap<TopicPartition, Long> fromAirbyteStreamState(final List<io.airbyte.protocol.models.AirbyteStreamState> states) {
+    final var result = new HashMap<TopicPartition, Long>();
+
+    for (final io.airbyte.protocol.models.AirbyteStreamState state : states) {
+      final var topic = state.getStreamDescriptor().getName();
+      final var stream = Jsons.convertValue(state.getStreamState(), State.class);
+
+      for (final Entry<Integer, Long> entry : stream.partitions().entrySet()) {
+        final var partition = entry.getKey();
+        final var offset = entry.getValue();
+
+        result.put(new TopicPartition(topic, partition), offset);
+      }
+    }
+
+    return result;
+  }
+}

--- a/airbyte-integrations/connectors/source-kafka/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-kafka/src/main/resources/spec.json
@@ -48,7 +48,8 @@
               },
               "schema_registry_password": {
                 "type": "string",
-                "default": ""
+                "default": "",
+                "airbyte_secret": true
               }
             }
           }

--- a/airbyte-integrations/connectors/source-kafka/src/test-integration/resources/expected_spec.json
+++ b/airbyte-integrations/connectors/source-kafka/src/test-integration/resources/expected_spec.json
@@ -1,5 +1,7 @@
 {
   "documentationUrl": "https://docs.airbyte.com/integrations/sources/kafka",
+  "supportsIncremental": true,
+  "supported_source_sync_modes": ["append"],
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Kafka Source Spec",
@@ -46,7 +48,8 @@
               },
               "schema_registry_password": {
                 "type": "string",
-                "default": ""
+                "default": "",
+                "airbyte_secret": true
               }
             }
           }
@@ -266,8 +269,5 @@
         "default": 100000
       }
     }
-  },
-  "supportsIncremental": true,
-  "supported_destination_sync_modes": [],
-  "supported_source_sync_modes": ["append"]
+  }
 }

--- a/airbyte-integrations/connectors/source-kafka/src/test/java/io/airbyte/integrations/source/kafka/converter/AvroConverterTest.java
+++ b/airbyte-integrations/connectors/source-kafka/src/test/java/io/airbyte/integrations/source/kafka/converter/AvroConverterTest.java
@@ -1,0 +1,101 @@
+package io.airbyte.integrations.source.kafka.converter;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Test;
+
+
+class AvroConverterTest {
+
+  @Test
+  void convertToAirbyteRecord() {
+
+    String rawSchema = """
+        {
+             "type": "record",
+             "name": "TestRecord",
+             "namespace": "mynamespace",
+             "fields": [{
+                 "name": "address",
+                 "type": {
+                     "type": "record",
+                     "name": "Address",
+                     "fields": [{
+                         "name": "number",
+                         "type": ["null", "string"],
+                         "default": null
+                     }, {
+                         "name": "postal_code",
+                         "type": "int"
+                     }, {
+                         "name": "street",
+                         "type": ["null", "string"],
+                         "default": null
+                     }]
+                 }
+             }, {
+                 "name": "name",
+                 "type": "string"
+                 
+             }, {
+                 "name": "skills",
+                 "type": ["null", {
+                     "type": "array",
+                     "items": ["null", "string"]
+                 }],
+                 "default": null
+             }, {
+                 "name": "surname",
+                 "type": "string"
+             }]
+         }
+        """;
+    Schema.Parser parser = new Schema.Parser();
+    Schema schema = parser.parse(rawSchema);
+
+    GenericRecord addressTestRecord = new GenericData.Record(schema.getField("address").schema());
+    addressTestRecord.put("street", "via fittizie");
+    addressTestRecord.put("number", "42");
+    addressTestRecord.put("postal_code", 12345);
+
+    List<String> skillsTestRecord = new LinkedList<>();
+    skillsTestRecord.add("coding");
+    skillsTestRecord.add("etl");
+
+    GenericRecord testRecord = new GenericData.Record(schema);
+    testRecord.put("name", "Team");
+    testRecord.put("surname", "Member");
+    testRecord.put("address", addressTestRecord);
+    testRecord.put("skills", skillsTestRecord);
+
+    String testTopic = "conversion.uk.test";
+
+    Converter<GenericRecord> converter = new AvroConverter();
+
+    AirbyteRecordMessage actualMessage = converter.convertToAirbyteRecord(testTopic, testRecord);
+    JsonNode actualData = actualMessage.getData();
+
+    List<String> expectedSkills = (List<String>) testRecord.get("skills");
+    List<String> actualSkills = new ArrayList<>();
+    actualData.get("skills").elements().forEachRemaining(x -> actualSkills.add(x.asText()));
+
+    assertAll(
+        () -> assertEquals(testTopic, actualMessage.getStream()),
+        () -> assertEquals(testRecord.get("name"), actualData.get("name").asText()),
+        () -> assertEquals(testRecord.get("surname"), actualData.get("surname").asText()),
+        () -> assertEquals(expectedSkills.stream().distinct().toList(), actualSkills.stream().distinct().toList()),
+        () -> assertEquals(addressTestRecord.get("street"), actualData.get("address").get("street").asText()),
+        () -> assertEquals(addressTestRecord.get("number"), actualData.get("address").get("number").asText()),
+        () -> assertEquals(addressTestRecord.get("postal_code"), actualData.get("address").get("postal_code").asInt())
+    );
+  }
+}

--- a/airbyte-integrations/connectors/source-kafka/src/test/java/io/airbyte/integrations/source/kafka/converter/JsonConverterTest.java
+++ b/airbyte-integrations/connectors/source-kafka/src/test/java/io/airbyte/integrations/source/kafka/converter/JsonConverterTest.java
@@ -1,0 +1,38 @@
+package io.airbyte.integrations.source.kafka.converter;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+import org.junit.jupiter.api.Test;
+
+class JsonConverterTest {
+
+  @Test
+  void testConvertToAirbyteRecord() throws JsonProcessingException {
+    String recordString = """
+        {
+           "name": "Team",
+           "surname": "Member",
+           "age": 42
+        }
+        """;
+
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode testRecord = mapper.readTree(recordString);
+
+    String testTopic = "test_topic";
+
+    Converter<JsonNode> converter = new JsonConverter();
+
+    AirbyteRecordMessage actualMessage = converter.convertToAirbyteRecord(testTopic, testRecord);
+
+    assertAll(
+        () -> assertEquals(testTopic, actualMessage.getStream()),
+        () -> assertEquals(testRecord, actualMessage.getData())
+    );
+  }
+}

--- a/airbyte-integrations/connectors/source-kafka/src/test/java/io/airbyte/integrations/source/kafka/generator/GeneratorTest.java
+++ b/airbyte-integrations/connectors/source-kafka/src/test/java/io/airbyte/integrations/source/kafka/generator/GeneratorTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.kafka.generator;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.source.kafka.KafkaMessage;
+import io.airbyte.integrations.source.kafka.mediator.KafkaMediator;
+import io.airbyte.integrations.source.kafka.state.State;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+import io.airbyte.protocol.models.v0.AirbyteStateMessage.AirbyteStateType;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.StreamSupport;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+public class GeneratorTest {
+
+  final int maxMessages = 1000;
+  final int maxRetries = 10;
+
+  @Test
+  public void testOneBatchNoState() {
+    final var mediator = new KafkaMediator() {
+
+      final String topic = "topic-0";
+      final Queue<KafkaMessage> messages = new LinkedList<>(
+          List.of(
+              new KafkaMessage(topic, 0, 0, new AirbyteRecordMessage().withStream(topic).withData(Jsons.deserialize("{ \"message\" : 1 }")))
+          )
+      );
+
+      @Override
+      public List<KafkaMessage> poll() {
+        return Optional.ofNullable(this.messages.poll()).stream().toList();
+      }
+
+      @Override
+      public Map<TopicPartition, Long> position(Set<TopicPartition> partitions) {
+        return Map.of();
+      }
+    };
+    final var generator = Generator.Builder.newInstance()
+        .withMaxRecords(maxMessages)
+        .withMaxRetries(maxRetries)
+        .withMediator(mediator)
+        .build();
+    final var messages = StreamSupport.stream(
+        Spliterators.spliteratorUnknownSize(generator.read(), Spliterator.ORDERED), false
+    ).toList();
+    final var expectedRecord = Jsons.deserialize("{ \"message\" : 1 }");
+
+    assertAll(
+        () -> assertEquals(1, messages.size()),
+        () -> assertEquals(AirbyteMessage.Type.RECORD, messages.get(0).getType()),
+        () -> assertEquals(expectedRecord, messages.get(0).getRecord().getData())
+    );
+  }
+
+  @Test
+  public void testOneBatchWithState() {
+    final var mediator = new KafkaMediator() {
+
+      final String topic = "topic-0";
+      final Queue<List<KafkaMessage>> messages = new LinkedList<>(
+          List.of(
+              List.of(
+                  new KafkaMessage(this.topic, 0, 0L,
+                      new AirbyteRecordMessage().withStream(this.topic).withData(Jsons.deserialize("{ \"message\" : 2 }"))),
+                  new KafkaMessage(this.topic, 1, 5L,
+                      new AirbyteRecordMessage().withStream(this.topic).withData(Jsons.deserialize("{ \"message\" : 3 }")))
+              )
+          )
+      );
+
+      @Override
+      public List<KafkaMessage> poll() {
+        return Optional.ofNullable(this.messages.poll()).orElse(List.of());
+      }
+
+      @Override
+      public Map<TopicPartition, Long> position(Set<TopicPartition> partitions) {
+        return Map.ofEntries(
+            Map.entry(new TopicPartition(this.topic, 0), 0L),
+            Map.entry(new TopicPartition(this.topic, 1), 5L)
+        );
+      }
+    };
+    final var generator = Generator.Builder.newInstance()
+        .withMaxRecords(maxMessages)
+        .withMaxRetries(maxRetries)
+        .withMediator(mediator)
+        .build();
+    final var messages = StreamSupport.stream(
+        Spliterators.spliteratorUnknownSize(generator.read(), Spliterator.ORDERED), false
+    ).toList();
+    final var expectedRecord1 = Jsons.deserialize("{ \"message\" : 2 }");
+    final var expectedRecord2 = Jsons.deserialize("{ \"message\" : 3 }");
+    final var expectedStateTopic = "topic-0";
+    final var expectedStateContent = Jsons.jsonNode(new State(Map.ofEntries(
+        Map.entry(0, 0L),
+        Map.entry(1, 5L)
+    )));
+
+    assertAll(
+        () -> assertEquals(3, messages.size()),
+        () -> assertEquals(AirbyteMessage.Type.RECORD, messages.get(0).getType()),
+        () -> assertEquals(expectedRecord1, messages.get(0).getRecord().getData()),
+        () -> assertEquals(AirbyteMessage.Type.RECORD, messages.get(1).getType()),
+        () -> assertEquals(expectedRecord2, messages.get(1).getRecord().getData()),
+        () -> assertEquals(AirbyteMessage.Type.STATE, messages.get(2).getType()),
+        () -> assertEquals(AirbyteStateType.STREAM, messages.get(2).getState().getType()),
+        () -> assertEquals(expectedStateTopic, messages.get(2).getState().getStream().getStreamDescriptor().getName()),
+        () -> assertEquals(expectedStateContent, messages.get(2).getState().getStream().getStreamState())
+    );
+  }
+
+  @Test
+  public void testMultipleBatches() {
+    final var mediator = new KafkaMediator() {
+
+      final String topic0 = "topic-0";
+      final String topic1 = "topic-2";
+
+      final Queue<List<KafkaMessage>> messages = new LinkedList<>(
+          List.of(
+              List.of(
+                  new KafkaMessage(this.topic0, 0, 0L,
+                      new AirbyteRecordMessage().withStream(this.topic0).withData(Jsons.deserialize("{ \"message\" : 4 }")))
+              ),
+              List.of(
+                  new KafkaMessage(this.topic1, 1, 5L,
+                      new AirbyteRecordMessage().withStream(this.topic1).withData(Jsons.deserialize("{ \"message\" : 5 }")))
+              )
+          )
+      );
+      final Queue<Map<TopicPartition, Long>> partitions = new LinkedList<>(
+          List.of(
+              Map.of(new TopicPartition(this.topic0, 0), 0L),
+              Map.of(new TopicPartition(this.topic1, 1), 5L)
+          )
+      );
+
+      @Override
+      public List<KafkaMessage> poll() {
+        return Optional.ofNullable(this.messages.poll()).orElse(List.of());
+      }
+
+      @Override
+      public Map<TopicPartition, Long> position(Set<TopicPartition> partitions) {
+        return Optional.ofNullable(this.partitions.poll()).orElse(Map.of());
+      }
+    };
+    final var generator = Generator.Builder.newInstance()
+        .withMaxRecords(maxMessages)
+        .withMaxRetries(maxRetries)
+        .withMediator(mediator)
+        .build();
+    final var messages = StreamSupport.stream(
+        Spliterators.spliteratorUnknownSize(generator.read(), Spliterator.ORDERED), false
+    ).toList();
+    final var expectedRecord1 = Jsons.deserialize("{ \"message\" : 4 }");
+    final var expectedRecord2 = Jsons.deserialize("{ \"message\" : 5 }");
+    final var expectedStateTopic1 = "topic-0";
+    final var expectedStateContent1 = Jsons.jsonNode(new State(Map.ofEntries(
+        Map.entry(0, 0L)
+    )));
+    final var expectedStateTopic2 = "topic-2";
+    final var expectedStateContent2 = Jsons.jsonNode(new State(Map.ofEntries(
+        Map.entry(1, 5L)
+    )));
+
+    assertAll(
+        () -> assertEquals(4, messages.size()),
+        () -> assertEquals(AirbyteMessage.Type.RECORD, messages.get(0).getType()),
+        () -> assertEquals(expectedRecord1, messages.get(0).getRecord().getData()),
+        () -> assertEquals(AirbyteMessage.Type.STATE, messages.get(1).getType()),
+        () -> assertEquals(AirbyteStateType.STREAM, messages.get(1).getState().getType()),
+        () -> assertEquals(expectedStateTopic1, messages.get(1).getState().getStream().getStreamDescriptor().getName()),
+        () -> assertEquals(expectedStateContent1, messages.get(1).getState().getStream().getStreamState()),
+        () -> assertEquals(AirbyteMessage.Type.RECORD, messages.get(2).getType()),
+        () -> assertEquals(expectedRecord2, messages.get(2).getRecord().getData()),
+        () -> assertEquals(AirbyteMessage.Type.STATE, messages.get(3).getType()),
+        () -> assertEquals(AirbyteStateType.STREAM, messages.get(3).getState().getType()),
+        () -> assertEquals(expectedStateTopic2, messages.get(3).getState().getStream().getStreamDescriptor().getName()),
+        () -> assertEquals(expectedStateContent2, messages.get(3).getState().getStream().getStreamState())
+    );
+  }
+
+  @Test
+  public void testRetriesNoData() {
+    final var mediator = new KafkaMediator() {
+
+      @Override
+      public List<KafkaMessage> poll() {
+        return List.of();
+      }
+
+      @Override
+      public Map<TopicPartition, Long> position(Set<TopicPartition> partitions) {
+        return Map.of();
+      }
+    };
+    final var generator = Generator.Builder.newInstance()
+        .withMaxRecords(maxMessages)
+        .withMaxRetries(maxRetries)
+        .withMediator(mediator)
+        .build();
+    final var messages = StreamSupport.stream(
+        Spliterators.spliteratorUnknownSize(generator.read(), Spliterator.ORDERED), false
+    ).toList();
+
+    assertTrue(messages.isEmpty());
+  }
+
+  @Test
+  public void testRetriesDataAfterSomeAttempts() {
+    final var mediator = new KafkaMediator() {
+
+      final String topic = "topic-0";
+      final Queue<List<KafkaMessage>> messages = new LinkedList<>(
+          List.of(
+              List.of(),
+              List.of(),
+              List.of(),
+              List.of(),
+              List.of(
+                  new KafkaMessage(this.topic, 0, 0L,
+                      new AirbyteRecordMessage().withStream(this.topic).withData(Jsons.deserialize("{ \"message\" : 6 }")))
+              )
+          )
+      );
+
+      @Override
+      public List<KafkaMessage> poll() {
+        return Optional.ofNullable(this.messages.poll()).orElse(List.of());
+      }
+
+      @Override
+      public Map<TopicPartition, Long> position(Set<TopicPartition> partitions) {
+        return Map.ofEntries(
+            Map.entry(new TopicPartition(this.topic, 0), 0L)
+        );
+      }
+    };
+    final var generator = Generator.Builder.newInstance()
+        .withMaxRecords(maxMessages)
+        .withMaxRetries(maxRetries)
+        .withMediator(mediator)
+        .build();
+    final var messages = StreamSupport.stream(
+        Spliterators.spliteratorUnknownSize(generator.read(), Spliterator.ORDERED), false
+    ).toList();
+    final var expectedRecord = Jsons.deserialize("{ \"message\" : 6 }");
+    final var expectedStateTopic = "topic-0";
+    final var expectedStateContent = Jsons.jsonNode(new State(Map.ofEntries(
+        Map.entry(0, 0L)
+    )));
+
+    assertAll(
+        () -> assertEquals(2, messages.size()),
+        () -> assertEquals(AirbyteMessage.Type.RECORD, messages.get(0).getType()),
+        () -> assertEquals(expectedRecord, messages.get(0).getRecord().getData()),
+        () -> assertEquals(AirbyteMessage.Type.STATE, messages.get(1).getType()),
+        () -> assertEquals(AirbyteStateType.STREAM, messages.get(1).getState().getType()),
+        () -> assertEquals(expectedStateTopic, messages.get(1).getState().getStream().getStreamDescriptor().getName()),
+        () -> assertEquals(expectedStateContent, messages.get(1).getState().getStream().getStreamState())
+    );
+  }
+}

--- a/airbyte-integrations/connectors/source-kafka/src/test/java/io/airbyte/integrations/source/kafka/state/StateHelperTest.java
+++ b/airbyte-integrations/connectors/source-kafka/src/test/java/io/airbyte/integrations/source/kafka/state/StateHelperTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.kafka.state;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.resources.MoreResources;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+public class StateHelperTest {
+
+  @Test
+  public void testGlobalStateDeserialisation() throws IOException {
+    final var jsonState = Jsons.deserialize(MoreResources.readResource("state/test_global_state_deserialisation.json"));
+    final var state = StateHelper.stateFromJson(jsonState);
+    final var expected = Map.ofEntries(
+        Map.entry(new TopicPartition("topic-0", 0), 42L)
+    );
+    assertEquals(expected, state);
+  }
+
+  @Test
+  public void testLegacyStateDeserialisation() throws IOException {
+    final var jsonState = Jsons.deserialize(MoreResources.readResource("state/test_legacy_state_deserialisation.json"));
+    final var state = StateHelper.stateFromJson(jsonState);
+    assertTrue(state.isEmpty());
+  }
+
+  @Test
+  public void testStreamStateDeserialisation() throws IOException {
+    final var jsonState = Jsons.deserialize(MoreResources.readResource("state/test_stream_state_deserialisation.json"));
+    final var state = StateHelper.stateFromJson(jsonState);
+    final var expected = Map.ofEntries(
+        Map.entry(new TopicPartition("topic-1", 0), 24L),
+        Map.entry(new TopicPartition("topic-1", 1), 42L)
+    );
+    assertEquals(expected, state);
+  }
+
+  @Test
+  public void testStateSerialisation() throws IOException {
+    final var state = Map.ofEntries(
+        Map.entry(new TopicPartition("topic-0", 0), 24L),
+        Map.entry(new TopicPartition("topic-1", 0), 42L),
+        Map.entry(new TopicPartition("topic-1", 1), 66L)
+    );
+    final var serialised = Jsons.serialize(StateHelper.toAirbyteState(state));
+    final var expected = MoreResources.readResource("state/test_state_serialisation.json");
+    assertEquals(expected, serialised);
+  }
+
+}
+

--- a/airbyte-integrations/connectors/source-kafka/src/test/resources/state/test_global_state_deserialisation.json
+++ b/airbyte-integrations/connectors/source-kafka/src/test/resources/state/test_global_state_deserialisation.json
@@ -1,0 +1,1 @@
+[{"type":"GLOBAL","global":{"shared_state":{},"stream_states":[{"stream_descriptor":{"name":"topic-0"},"stream_state":{"partitions":{"0":42}}}]}}]

--- a/airbyte-integrations/connectors/source-kafka/src/test/resources/state/test_legacy_state_deserialisation.json
+++ b/airbyte-integrations/connectors/source-kafka/src/test/resources/state/test_legacy_state_deserialisation.json
@@ -1,0 +1,1 @@
+[{"type":"LEGACY","data":{"stream_descriptor":{"name":"topic-0"},"stream_state":{"partitions":{"0":42}}}}]

--- a/airbyte-integrations/connectors/source-kafka/src/test/resources/state/test_state_serialisation.json
+++ b/airbyte-integrations/connectors/source-kafka/src/test/resources/state/test_state_serialisation.json
@@ -1,0 +1,1 @@
+[{"type":"STREAM","stream":{"stream_descriptor":{"name":"topic-0"},"stream_state":{"partitions":{"0":24}}}},{"type":"STREAM","stream":{"stream_descriptor":{"name":"topic-1"},"stream_state":{"partitions":{"0":42,"1":66}}}}]

--- a/airbyte-integrations/connectors/source-kafka/src/test/resources/state/test_stream_state_deserialisation.json
+++ b/airbyte-integrations/connectors/source-kafka/src/test/resources/state/test_stream_state_deserialisation.json
@@ -1,0 +1,1 @@
+[{"type":"STREAM","stream":{"stream_descriptor":{"name":"topic-1"},"stream_state":{"partitions":{"0":24,"1":42}}}}]


### PR DESCRIPTION
## What

This PR is refactoring the kafka source to make it easier to add state support.

## How

Instead of relying on kafka offset management, this PR is managing the offsets manually and using Airbyte state to keep track of the consumed offsets per topic and partition.

## 🚨 User Impact 🚨

The source will not commit offsets to kafka; this can be considered a breaking change. Version will be bumped to 0.3.0.
